### PR TITLE
Fix Doxygen CI to use doxygen v1.8.18

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,8 +1,9 @@
 name: Doxygen CI
 
 on:
-  push:
-    branches: [master]
+  [push]
+  # push:
+  #   branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,8 +14,8 @@ jobs:
           submodules: true
       - name: Install requirements
         run: |
-          sudo brew install graphviz ninja-build
-          sudo brew install doxygen
+          brew install graphviz ninja-build
+          brew install doxygen
       - name: configure
         run: cmake -G Ninja -B ./build -S .
       - name: build

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,7 +14,7 @@ jobs:
           submodules: true
       - name: Install requirements
         run: |
-          brew install graphviz ninja-build
+          brew install graphviz ninja
           brew install doxygen
       - name: configure
         run: cmake -G Ninja -B ./build -S .

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,15 +7,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@master
         with:
           submodules: true
       - name: Install requirements
         run: |
-          sudo apt -qq -y update
-          sudo apt -qq install graphviz ninja-build
+          sudo brew install graphviz ninja-build
           sudo brew install doxygen
       - name: configure
         run: cmake -G Ninja -B ./build -S .

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,7 +15,8 @@ jobs:
       - name: Install requirements
         run: |
           sudo apt -qq -y update
-          sudo apt -qq install doxygen graphviz ninja-build
+          sudo apt -qq install graphviz ninja-build
+          sudo brew install doxygen
       - name: configure
         run: cmake -G Ninja -B ./build -S .
       - name: build

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,9 +1,8 @@
 name: Doxygen CI
 
 on:
-  [push]
-  # push:
-  #   branches: [master]
+  push:
+    branches: [master]
 
 jobs:
   build:
@@ -14,8 +13,7 @@ jobs:
           submodules: true
       - name: Install requirements
         run: |
-          brew install graphviz ninja
-          brew install doxygen
+          brew install graphviz ninja doxygen
       - name: configure
         run: cmake -G Ninja -B ./build -S .
       - name: build

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # The Algorithms - C++ # {#mainpage}
-[![contributions welcome](https://img.shields.io/static/v1.svg?label=Contributions&message=Welcome&color=0059b3&style=flat-square)](https://github.com/kvedala/C-Plus-Plus/blob/master/CONTRIBUTION.md)&nbsp;
+[<img src="https://img.shields.io/static/v1.svg?label=Contributions&message=Welcome&color=0059b3&style=flat-square" alt="contributions welcome"/>](https://github.com/kvedala/C-Plus-Plus/blob/master/CONTRIBUTION.md)
 ![GitHub repo size](https://img.shields.io/github/repo-size/kvedala/C-Plus-Plus?color=red&style=flat-square)
 ![GitHub closed pull requests](https://img.shields.io/github/issues-pr-closed/kvedala/C-Plus-Plus?color=green&style=flat-square)
-![Doxygen CI](https://github.com/kvedala/C-Plus-Plus/workflows/Doxygen%20CI/badge.svg)
-![cpplint](https://github.com/kvedala/C-Plus-Plus/workflows/cpplint_modified_files/badge.svg)
-![C/C++ CI](https://github.com/kvedala/C-Plus-Plus/workflows/C/C++%20CI/badge.svg)
+<img src="https://github.com/kvedala/C-Plus-Plus/workflows/Doxygen%20CI/badge.svg" alt="Doxygen CI"/>
+<img src="https://github.com/kvedala/C-Plus-Plus/workflows/cpplint_modified_files/badge.svg" alt="cpplint status"/>
+<img src="https://github.com/kvedala/C-Plus-Plus/workflows/C/C++%20CI/badge.svg" alt="C/C++ CI" />
 
 [Documentation](https://kvedala.github.io/C-Plus-Plus)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # The Algorithms - C++ # {#mainpage}
-[<img src="https://img.shields.io/static/v1.svg?label=Contributions&message=Welcome&color=0059b3&style=flat-square" alt="contributions welcome"/>](https://github.com/kvedala/C-Plus-Plus/blob/master/CONTRIBUTION.md)
+[![contributions welcome](https://img.shields.io/static/v1.svg?label=Contributions&message=Welcome&color=0059b3&style=flat-square)](https://github.com/kvedala/C-Plus-Plus/blob/master/CONTRIBUTION.md)&nbsp;
 ![GitHub repo size](https://img.shields.io/github/repo-size/kvedala/C-Plus-Plus?color=red&style=flat-square)
 ![GitHub closed pull requests](https://img.shields.io/github/issues-pr-closed/kvedala/C-Plus-Plus?color=green&style=flat-square)
-<img src="https://github.com/kvedala/C-Plus-Plus/workflows/Doxygen%20CI/badge.svg" alt="Doxygen CI"/>
-<img src="https://github.com/kvedala/C-Plus-Plus/workflows/cpplint_modified_files/badge.svg" alt="cpplint status"/>
-<img src="https://github.com/kvedala/C-Plus-Plus/workflows/C/C++%20CI/badge.svg" alt="C/C++ CI" />
+![Doxygen CI](https://github.com/kvedala/C-Plus-Plus/workflows/Doxygen%20CI/badge.svg)
+![cpplint](https://github.com/kvedala/C-Plus-Plus/workflows/cpplint_modified_files/badge.svg)
+![C/C++ CI](https://github.com/kvedala/C-Plus-Plus/workflows/C/C++%20CI/badge.svg)
 
 [Documentation](https://kvedala.github.io/C-Plus-Plus)
 


### PR DESCRIPTION
## Updates
GitHub ubuntu has doxygen v1.8.13 which breaks the image links in README.md at the root folder. Switched to MacOS and home-brew to perform the Github Actions